### PR TITLE
fix: documentation on service_account_int_id to be of type string

### DIFF
--- a/docs/guides/sample-project.md
+++ b/docs/guides/sample-project.md
@@ -224,8 +224,8 @@ Save your Kafka API key and secret in a secure location.
     }
 
     variable "service_account_int_id" {
-      type = number
-      description = "Service Account Integer ID"
+      type = string
+      description = "Service Account ID"
     }
     ```
 


### PR DESCRIPTION
The documentation on how to create the variables.tf file is incorrect.
It is specifying that service account id's are of type number, however they are actually of type string using the following format:
```
sa-2f2asd
```

This pr updates the documentation to correct that