### PR TITLE
enable confluent cloud platform roles for role bindings in ccloud …

### DIFF
--- a/internal/provider/resource_role_binding.go
+++ b/internal/provider/resource_role_binding.go
@@ -31,7 +31,7 @@ const (
 	paramCrnPattern = "crn_pattern"
 )
 
-var acceptedRbacRoleNames = []string{"MetricsViewer", "CloudClusterAdmin", "OrganizationAdmin", "EnvironmentAdmin","ResourceOwner","DeveloperRead","DeveloperWrite","DeveloperManage","Operator","AuditAdmin","SecurityAdmin","UserAdmin","SystemAdmin"}
+var acceptedRbacRoleNames = []string{"MetricsViewer", "CloudClusterAdmin", "OrganizationAdmin", "EnvironmentAdmin", "ResourceOwner", "DeveloperRead", "DeveloperWrite", "DeveloperManage", "Operator", "AuditAdmin", "SecurityAdmin", "UserAdmin", "SystemAdmin"}
 
 func roleBindingResource() *schema.Resource {
 	return &schema.Resource{

--- a/internal/provider/resource_role_binding.go
+++ b/internal/provider/resource_role_binding.go
@@ -31,7 +31,7 @@ const (
 	paramCrnPattern = "crn_pattern"
 )
 
-var acceptedRbacRoleNames = []string{"MetricsViewer", "CloudClusterAdmin", "OrganizationAdmin", "EnvironmentAdmin"}
+var acceptedRbacRoleNames = []string{"MetricsViewer", "CloudClusterAdmin", "OrganizationAdmin", "EnvironmentAdmin","ResourceOwner","DeveloperRead","DeveloperWrite","DeveloperManage","Operator","AuditAdmin","SecurityAdmin","UserAdmin","SystemAdmin"}
 
 func roleBindingResource() *schema.Resource {
 	return &schema.Resource{


### PR DESCRIPTION
Hi !
In our company we start to use RBAC with cloud platform predefined roles in our confluent cloud subscription. We'd like very much to provision it through terraform that is our reference provisionning tool.
My modification was just to add new accepted roles in role validation. It seems to me that is enough because today the resource definition is done through crn pattern that seems very generic.

Please don't hesitate if you have any question or remarks.