### PR TITLE
Enable CI build improvement for terraform-provider-confluentcloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 
 # Bin dir
 bin/

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,14 @@ NAME        := terraform-provider-confluentcloud
 BUILD_DIR   := bin
 VERSION     ?= $(shell git describe --tags --exact-match 2>/dev/null || git describe --tags 2>/dev/null || echo "v0.0.0-$(COMMIT_HASH)")
 # Go variables
-GOCMD       := GO111MODULE=on go
-GOBUILD     ?= CGO_ENABLED=0 $(GOCMD) build -mod=mod
-GOOS        ?= $(shell go env GOOS)
-GOARCH      ?= $(shell go env GOARCH)
-GOFILES     ?= $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+GOCMD         := GO111MODULE=on go
+GOBUILD       ?= CGO_ENABLED=0 $(GOCMD) build -mod=vendor
+GOOS          ?= $(shell go env GOOS)
+GOARCH        ?= $(shell go env GOARCH)
+GOFILES       ?= $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 .PHONY: all
-all: clean test testacc tools lint lint-licenses build
+all: clean deps test testacc tools lint lint-licenses build
 
 
 .PHONY: checkfmt
@@ -46,6 +46,11 @@ lint: ## Run linter
 clean: ## Clean workspace
 	@ $(MAKE) --no-print-directory log-$@
 	rm -rf ./$(BUILD_DIR)
+
+.PHONY: deps
+deps: ## Fetch dependencies
+	@ $(MAKE) --no-print-directory log-$@
+	$(GOCMD) mod vendor
 
 .PHONY: build
 build: clean ## Build binary for current OS/ARCH

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -14,6 +14,7 @@
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `bin` directory.
 
 ```shell
+$ make deps
 $ make build
 ```
 

--- a/make.includes
+++ b/make.includes
@@ -3,6 +3,7 @@ DEFAULT_BUMP := patch
 
 include ./mk-include/cc-begin.mk
 include ./mk-include/cc-semver.mk
+include ./mk-include/cc-semaphore.mk
 include ./mk-include/cc-go.mk
 include ./mk-include/cc-vault.mk
 include ./mk-include/cc-end.mk


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
APIF-2039 Enable DevProd CI build time improvements

Enabled in this commit:
1. Enabling Go Vendor and Enable semaphore caching
    - go vendor is enabled by updating `-mod=vendor` in the go build command
    - Semaphore caching is enabled by adding ` include ./mk-include/cc-semaphore.mk`
    - added build target deps to pull the vendoring repos

Also updated .gitignore for the vendor folder.

Not applicable:
1. Enable cc-mk-include auto update so there is no need for manual update
    - This repo does not have a mk-include folder.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
Instructions on enabling cc-mk-include and go caching.
https://confluentinc.atlassian.net/browse/APIF-2039
https://confluent.slack.com/archives/C038ZJ00P/p1639685684084100

Test&Review
------------

<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
